### PR TITLE
documentation: Se actualiza el update y el post en la documentación

### DIFF
--- a/openApi.yml
+++ b/openApi.yml
@@ -94,7 +94,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/createModifyAsset"
+              $ref: "#/components/schemas/modifyAsset"
       responses:
         '200':
           description: Everything is OK
@@ -184,7 +184,16 @@ components:
       properties:
         file:
           type: string
-          description: Asset's URL stored in Google Photos
+          description: Image that the user wants to upload converted to base64
+        name:
+          type: string
+          description: Asset's name
+        user:
+          type: string
+          description: User that owns the asset
+    modifyAsset:
+      type: object
+      properties:
         name:
           type: string
           description: Asset's name


### PR DESCRIPTION
Ya que ahora para crear un asset es necesario pasarle la imagen en base64 y no se puede actualizar el campo file. Issue #61